### PR TITLE
Disable numba for regridding & update bash script for 1deg only

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "initial_conditions_WOA"]
 	path = initial_conditions_WOA
-	url = https://github.com/COSIMA/initial_conditions_WOA.git
+	url = https://github.com/minghangli-uni/initial_conditions_WOA.git


### PR DESCRIPTION
This PR provides a working version for generating temperature and salinity initial conditions specifically for the 1deg config. It is trivial to make adjustments for the 025deg and 01deg configurations. 

Please note that running this script requires an older version of Python and disabling `numba`, as it does not support NumPy masked arrays. For more information, refer to https://github.com/COSIMA/initial_conditions_access-om2/issues/3.